### PR TITLE
Change the license from MIT to public domain

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,22 +1,24 @@
-Copyright (c) 2015 Kata Seeds
+This is free and unencumbered software released into the public domain.
 
-MIT License
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>


### PR DESCRIPTION
The [current license](https://github.com/roryokane/kata-seed-template/blob/9b5a779e4282b4c30077601fef6cd15b80b91e7a/LICENSE.txt) is the [MIT License](http://choosealicense.com/licenses/mit/). I don’t have a problem with that license usually, but for this project, there is a bad side effect. Since kata seeds are templates that are downloaded and built upon, all projects built from them also include the same `LICENSE.txt`. And the MIT License includes these portions:

> Copyright (c) 2015 Kata Seeds

<!-- break -->

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

This means that any projects built with a Kata Seed as a starting point – whether they are a code kata exercise or a full-fledged library or app – must preserve the copyright notice. The license file must always state that the project is copyright Kata Seeds – even though a kata seed doesn’t provide much, so the project creator probably did 95% of the work.

To avoid this problem, I think it would be better to license kata seeds under the public domain. “Public domain” is the only type of license listed at [ChooseALicense.com](http://choosealicense.com/licenses/) (a site made by GitHub) that avoids the above problem. A public domain license would allow project creators who use kata seeds to relicense their proejct however they want, including changing the copyright notice.

It comes with the side effect that project creators could make their projects closed-source, since there is no requirement that the license of derivative works be the same. This could be seen as a downside. However, for project templates like these that take only half an hour to reproduce from scratch, I don’t think it really matters. If someone wanted to create a closed-source project, they aren’t going to remember Kata Seeds and decide to make the project open-source just to save themselves 30 minutes of setup time.

The Unlicense was chosen among licenses for public domain software because it is recommended on [Licenses – ChooseALicense.com](http://choosealicense.com/licenses/). The text in this pull request is from [Public Domain (Unlicense) – ChooseALicense.com](http://choosealicense.com/licenses/unlicense/).

If you really want keep the kata seed template MIT-licensed, an alternative is to preface or reword the license so that it clearly applies only to the template itself, and not any projects that are built from it.
